### PR TITLE
Fix Docker Compose Network Configuration

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -11,7 +11,7 @@ services:
       - "./client:/app"
       - "/app/node_modules"
     networks:
-      cafe_network: { }
+      - cafe_network
 
   server:
     container_name: server
@@ -29,7 +29,7 @@ services:
     depends_on:
       - database
     networks:
-      cafe_network: { }
+      - cafe_network
 
   database:
     container_name: database
@@ -45,10 +45,10 @@ services:
     ports:
       - "5432:5432"
     networks:
-      cafe_network: { }
+      - cafe_network
 
 networks:
-  cafe_network: { }
+  cafe_network:
 
 volumes:
-  postgres_data: { }
+  postgres_data:


### PR DESCRIPTION
## Details
Addresses an issue with the Docker Compose configuration where the networks section was incorrectly set up. This misconfiguration prevented proper communication between the client and server containers, leading to connection issues.